### PR TITLE
Update devices (may 2025) and SDK to `8.1.1`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV CONNECT_IQ_HOME=/connectiq
 RUN mkdir -p ${CONNECT_IQ_HOME}
 
 # hardcoding the version for now
-ENV CONNECT_IQ_VERSION=7.4.3
+ENV CONNECT_IQ_VERSION=8.1.1
 
 # download the SDK
 COPY downloader.sh /root/downloader.sh


### PR DESCRIPTION
This pull request updates the `Dockerfile` to use a newer version of the Connect IQ SDK.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L17-R17): Updated the `CONNECT_IQ_VERSION` environment variable from `7.4.3` to `8.1.1`, ensuring the project uses the latest SDK version.